### PR TITLE
Fixed behavior of Instruction_8xy5 and Instruction_8xy7 and added Cpu.AllowQuirks flag.

### DIFF
--- a/src/Chip8.Tests/Instructions/Instruction_8xy5Tests.cs
+++ b/src/Chip8.Tests/Instructions/Instruction_8xy5Tests.cs
@@ -8,7 +8,7 @@ namespace Chip8.Tests.Instructions;
 public class Instruction_8xy5Tests : BaseInstructionTests
 {
   [TestCase(0xFE, 0x01, 0xFD, 1)]
-  [TestCase(0x01, 0xFE, 0xFD, 0)]
+  [TestCase(0x01, 0x02, 0xFF, 0)]
   [TestCase(0x02, 0x02, 0x00, 1)]
   public void Executing_Instruction_8xy5_WorksAsExpected(byte value1, byte value2, byte expectedResult, byte expectedVF)
   {
@@ -26,12 +26,28 @@ public class Instruction_8xy5Tests : BaseInstructionTests
   }
 
   [Test]
-  public void Executing_Instruction_8xy5_WithVx_SetToVF_ThrowsException()
+  public void Executing_Instruction_8xy5_WithVx_SetToVF_WithQuirksNotAllowed_ThrowsException()
   {
     var cpu = new Cpu();
     var decodedInstruction = new DecodedInstruction(0x8FB5);
 
     var instruction = new Instruction_8xy5(decodedInstruction);
     Assert.Throws<InvalidOperationException>(() => instruction.Execute(cpu, MockedDisplay, MockedKeyboard));
+  }
+
+  [Test]
+  public void Executing_Instruction_8xy5_WithVx_SetToVF_WithQuirksAllowed_WorksAsExpected()
+  {
+    var cpu = new Cpu(true);
+    var decodedInstruction = new DecodedInstruction(0x8FB5);
+    cpu.V[decodedInstruction.x] = 0xFE;
+    cpu.V[decodedInstruction.y] = 0x01;
+    byte expectedResult = 0xFD;
+
+    var instruction = new Instruction_8xy5(decodedInstruction);
+    instruction.Execute(cpu, MockedDisplay, MockedKeyboard);
+
+    Assert.That(cpu.V[decodedInstruction.x], Is.EqualTo(expectedResult));
+    Assert.That(cpu.V[0xF], Is.EqualTo(expectedResult));
   }
 }

--- a/src/Chip8.Tests/Instructions/Instruction_8xy7Tests.cs
+++ b/src/Chip8.Tests/Instructions/Instruction_8xy7Tests.cs
@@ -7,8 +7,8 @@ namespace Chip8.Tests.Instructions;
 [TestFixture]
 public class Instruction_8xy7Tests : BaseInstructionTests
 {
-  [TestCase(0xFE, 0x01, 0xFD, 0)]
   [TestCase(0x01, 0xFE, 0xFD, 1)]
+  [TestCase(0x02, 0x01, 0xFF, 0)]
   [TestCase(0x02, 0x02, 0x00, 1)]
   public void Executing_Instruction_8xy7_WorksAsExpected(byte value1, byte value2, byte expectedResult, byte expectedVF)
   {
@@ -26,12 +26,28 @@ public class Instruction_8xy7Tests : BaseInstructionTests
   }
 
   [Test]
-  public void Executing_Instruction_8xy7_WithVx_SetToVF_ThrowsException()
+  public void Executing_Instruction_8xy7_WithVx_SetToVF_WithQuirksNotAllowed_ThrowsException()
   {
     var cpu = new Cpu();
     var decodedInstruction = new DecodedInstruction(0x8FB7);
 
     var instruction = new Instruction_8xy7(decodedInstruction);
     Assert.Throws<InvalidOperationException>(() => instruction.Execute(cpu, MockedDisplay, MockedKeyboard));
+  }
+
+  [Test]
+  public void Executing_Instruction_8xy7_WithVx_SetToVF_WithQuirksAllowed_WorksAsExpected()
+  {
+    var cpu = new Cpu(true);
+    var decodedInstruction = new DecodedInstruction(0x8FB7);
+    cpu.V[decodedInstruction.x] = 0x01;
+    cpu.V[decodedInstruction.y] = 0xFE;
+    byte expectedResult = 0xFD;
+
+    var instruction = new Instruction_8xy7(decodedInstruction);
+    instruction.Execute(cpu, MockedDisplay, MockedKeyboard);
+
+    Assert.That(cpu.V[decodedInstruction.x], Is.EqualTo(expectedResult));
+    Assert.That(cpu.V[0xF], Is.EqualTo(expectedResult));
   }
 }

--- a/src/Chip8/Cpu.cs
+++ b/src/Chip8/Cpu.cs
@@ -93,7 +93,19 @@ public class Cpu
 
   #region Constructor and methods
 
-  public Cpu(bool allowQuirks = false)
+  /// <summary>
+  /// Initializes a new instance of the <see cref="Cpu"/> class with default settings.
+  /// </summary>
+  public Cpu()
+    : this(false)
+  {
+  }
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="Cpu"/> class with explicitly set <paramref name="allowQuirks"/>.
+  /// </summary>
+  /// <param name="allowQuirks">Used to set <see cref="Cpu.AllowQuirks"/> property.</param>
+  public Cpu(bool allowQuirks)
   {
     AllowQuirks = allowQuirks;
     Reset();

--- a/src/Chip8/Cpu.cs
+++ b/src/Chip8/Cpu.cs
@@ -75,12 +75,27 @@ public class Cpu
   /// </summary>
   public readonly byte[] Memory = new byte[MemorySizeInBytes];
 
+  /// <summary>
+  /// Gets a value indicating whether the system operates in quirks mode.<br></br>
+  /// When quirks mode is set to false (default), following CPU instructions will throw an 
+  /// <see cref="InvalidOperationException"/> if unusual memory operations are attempted:<br></br>
+  /// - <see cref="Instructions.Instruction_8xy5"/> when Vx is set to VF<br></br>
+  /// - <see cref="Instructions.Instruction_8xy7"/> when Vx is set to VF<br></br>
+  /// </summary>
+  /// <remarks>
+  /// Standard Chip-8 ROMs usually do not need the quirks mode enabled.<br></br>
+  /// The only exception to that is the 
+  /// <see href="https://github.com/Timendus/chip8-test-suite">CHIP-8 test suite by Timendus</see>.
+  /// </remarks>
+  public bool AllowQuirks { get; }
+
   #endregion
 
   #region Constructor and methods
 
-  public Cpu()
+  public Cpu(bool allowQuirks = false)
   {
+    AllowQuirks = allowQuirks;
     Reset();
     FontData.Data.CopyTo(Memory, 0);
   }

--- a/src/Chip8/Instructions/Instruction_8xy7.cs
+++ b/src/Chip8/Instructions/Instruction_8xy7.cs
@@ -6,7 +6,9 @@ namespace Chip8.Instructions;
 /// Set Vx = Vy - Vx, set VF = NOT borrow.
 /// </summary>
 /// <remarks>
-/// If Vy >= Vx, then VF is set to 1, otherwise 0. Then Vx is subtracted from Vy, and the results stored in Vx.
+/// If Vy >= Vx, then VF is set to 1, otherwise 0.<br></br>
+/// Then Vx is subtracted from Vy, and the results stored in Vx.<br></br>
+/// NOTE: Subtraction is byte-wise subtraction with wrap-around (e.g., 0 - 1 = 255).
 /// </remarks>
 public class Instruction_8xy7 : CpuInstruction
 {
@@ -19,13 +21,19 @@ public class Instruction_8xy7 : CpuInstruction
   /// <inheritdoc/>
   public override void Execute(Cpu cpu, IDisplay display, IKeyboard keyboard)
   {
-    if (Decoded.x == 0xF)
+    if (Decoded.x == 0xF && !cpu.AllowQuirks)
     {
       throw new InvalidOperationException("Cannot use VF as Vx register of SUBN operation. VF is already storing the !borrow flag so it cannot store the result also.");
     }
 
-    var sum = Math.Abs(cpu.V[Decoded.y] - cpu.V[Decoded.x]);
-    cpu.V[0xF] = (cpu.V[Decoded.y] >= cpu.V[Decoded.x]) ? (byte)1 : (byte)0;
-    cpu.V[Decoded.x] = (byte)sum;
+    // Read as ints to avoid byte arithmetic surprises
+    int vx = cpu.V[Decoded.x];
+    int vy = cpu.V[Decoded.y];
+
+    // VF = 1 when no borrow (Vy >= Vx), otherwise 0
+    cpu.V[0xF] = (byte)(vy >= vx ? 1 : 0);
+
+    // Store result modulo 256 (byte cast wraps)
+    cpu.V[Decoded.x] = (byte)(vy - vx);
   }
 }


### PR DESCRIPTION
* instructions were previously doing absolute subtraction (e.g., 0 - 1 = abs(result) =1)
* now they are implementing byte-wise subtraction with wrap-around (e.g., 0 - 1 = 255)
* added Cpu.AllowQuirks which affects behavior of Instruction_8xy5 and Instruction_8xy7 (when Vx is set to VF)

