### PR TITLE
Emulator rewrite.

### DIFF
--- a/src/Chip8.Tests/EmulatorTests.cs
+++ b/src/Chip8.Tests/EmulatorTests.cs
@@ -46,6 +46,7 @@ public class EmulatorTests
   {
     var displayMock = new Mock<IDisplay>(MockBehavior.Strict);
     displayMock.Setup(x => x.Clear());
+    displayMock.Setup(x => x.RenderIfDirty());
 
     var emulator = new Emulator(_cpu, displayMock.Object, _keyboard);
     emulator.LoadApplication(_applicationWhichClearsScreenInLoop);

--- a/src/Chip8.Tests/InstructionExecutorTests.cs
+++ b/src/Chip8.Tests/InstructionExecutorTests.cs
@@ -61,11 +61,10 @@ public class InstructionExecutorTests
   }
 
   [Test]
-  public void ExecutingInstruction_DecrementsTimers()
+  public void ExecutingInstruction_DoesNotDecrementTimers()
   {
     var cpu = new Cpu();
     cpu.Memory[Cpu.MemoryAddressOfFirstInstruction + 1] = 0xE0; // CLS instruction
-    cpu.Memory[Cpu.MemoryAddressOfFirstInstruction + 3] = 0xE0; // CLS instruction
 
     // initial value of timers
     cpu.DT = 1;
@@ -73,14 +72,8 @@ public class InstructionExecutorTests
 
     var instructionExecutor = new InstructionExecutor(cpu, _display, _keyboard);
 
-    // first execution
     instructionExecutor.ExecuteSingleInstruction();
-    Assert.That(cpu.DT, Is.EqualTo(0));
-    Assert.That(cpu.ST, Is.EqualTo(0));
-
-    // second execution
-    instructionExecutor.ExecuteSingleInstruction();
-    Assert.That(cpu.DT, Is.EqualTo(0));
-    Assert.That(cpu.ST, Is.EqualTo(0));
+    Assert.That(cpu.DT, Is.EqualTo(1));
+    Assert.That(cpu.ST, Is.EqualTo(1));
   }
 }

--- a/src/Chip8/Emulator.cs
+++ b/src/Chip8/Emulator.cs
@@ -19,8 +19,8 @@ public class Emulator : IDisposable
   private readonly InstructionExecutor _instructionExecutor;
   private readonly StringBuilder _stringBuilder = new StringBuilder();
 
-  private int _instructionsPerSecond = 0;
-  private int _framesPerSecond = 0;
+  private int _instructionsPerSecond;
+  private int _framesPerSecond;
 
   private bool _isDisposed;
 
@@ -309,8 +309,14 @@ public class Emulator : IDisposable
       {
         while (timerAccumulator >= TimerCycleTimeMs)
         {
-          if (_cpu.DT > 0) _cpu.DT--;
-          if (_cpu.ST > 0) _cpu.ST--;
+          if (_cpu.DT > 0)
+          {
+            _cpu.DT--;
+          }
+          if (_cpu.ST > 0)
+          {
+            _cpu.ST--;
+          }
 
           timerAccumulator -= TimerCycleTimeMs;
         }

--- a/src/Chip8/IDisplay.cs
+++ b/src/Chip8/IDisplay.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Abstraction of Chip-8 screen.
 /// Screen is a 64x32-pixel monochrome display with the origin (0,0) in the top left corner.
+/// It is recommended to use a buffer for all methods except <see cref="RenderIfDirty"/> to avoid excessive writes to the display.
 /// </summary>
 public interface IDisplay
 {
@@ -32,4 +33,10 @@ public interface IDisplay
   /// <param name="x">Pixel column.</param>
   /// <param name="y">Pixel row.</param>
   void SetPixel(byte x, byte y);
+
+  /// <summary>
+  /// Renders the content if it has been marked as dirty since the last render operation.
+  /// This method is called in a regular interval (e.g. 60 Hz) to update the display.
+  /// </summary>
+  void RenderIfDirty();
 }

--- a/src/Chip8/InstructionExecutor.cs
+++ b/src/Chip8/InstructionExecutor.cs
@@ -39,18 +39,6 @@ public class InstructionExecutor
       _cpu.PC += 2;
     }
 
-    // decrement delay timer
-    if (_cpu.DT > 0)
-    {
-      _cpu.DT--;
-    }
-
-    // decrement sound timer
-    if (_cpu.ST > 0)
-    {
-      _cpu.ST--;
-    }
-
     return cpuInstruction;
   }
 


### PR DESCRIPTION
* instead of running both ST/DT timers and CPU at 60Hz, CPU now runs at 500Hz and timers remain at 60Hz
* Emulator.ExecuteCycle now uses accumulators to catch up
* rendering is now done frame-by-frame instead of pixel-by-pixel
* added GetInstructionsPerSecond and GetFramesPerSecond methods to emulator
* IDisplay.RenderIfDirty method added